### PR TITLE
Fix target option parsing in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,9 +26,9 @@ with open(readme_path, 'r') as stream:
 # Check if GPU target is specified.
 if '--target' in sys.argv:
     target_index = sys.argv.index('--target') + 1
-    target = sys.argv[target_index].lower()
-    sys.argv.remove('--target')
+    device_target = sys.argv[target_index].lower()
     sys.argv.pop(target_index)
+    sys.argv.remove('--target')
 
 # GPU target compatibility check.
 if device_target == 'gpu':


### PR DESCRIPTION
# [Spleeter-] -  Fix target option parsing in setup.py #47 

## Description

The parsing of target  was not using the proper variable

## How this patch was tested

Tested by providing --target gpu to command line and verifying that tensorflow-gpu variant was installed.

