### PR TITLE
Fix tuple bug in output directory name

### DIFF
--- a/spleeter/separator.py
+++ b/spleeter/separator.py
@@ -121,7 +121,7 @@ class Separator(object):
             duration=duration,
             sample_rate=self._sample_rate)
         sources = self.separate(waveform)
-        filename = splitext(basename(audio_descriptor))
+        filename = splitext(basename(audio_descriptor))[0]
         generated = []
         for instrument, data in sources.items():
             path = join(destination, filename_format.format(

--- a/tests/test_separator.py
+++ b/tests/test_separator.py
@@ -9,7 +9,7 @@ __license__ = 'MIT License'
 
 import filecmp
 
-from os.path import splitext, exists, join
+from os.path import splitext, basename, exists, join
 from tempfile import TemporaryDirectory
 
 import pytest
@@ -19,7 +19,7 @@ from spleeter.audio.adapter import get_default_audio_adapter
 from spleeter.separator import Separator
 
 TEST_AUDIO_DESCRIPTOR = 'audio_example.mp3'
-TEST_AUDIO_BASENAME = splitext(TEST_AUDIO_DESCRIPTOR)
+TEST_AUDIO_BASENAME = splitext(basename(TEST_AUDIO_DESCRIPTOR))[0]
 TEST_CONFIGURATIONS = [
     ('spleeter:2stems', ('vocals', 'accompaniment')),
     ('spleeter:4stems', ('vocals', 'drums', 'bass', 'other')),


### PR DESCRIPTION
# [Spleeter] - Fix tuple bug in output directory name

## Description

This PR resolves #130 by adding a `[0]` to the output of the `splitext` function.

`splitext` returns a tuple, but the current code acts as if the function returns a string, resulting in parentheses and generally odd formatting in the output directory name.

The bug is specific to the `separator.py` file.

## How this patch was tested

I ran `pytest` locally on my Mac to test these changes. I also updated the test file to accommodate this change.

## Documentation link and external references

I added [comments](https://github.com/deezer/spleeter/commit/ced4028ce87d1cc313936c744cec5bb79eb911b8#commitcomment-36103084) to the commit that introduced this bug.
