### PR TITLE
fix unknown encoder error

### DIFF
--- a/spleeter/audio/ffmpeg.py
+++ b/spleeter/audio/ffmpeg.py
@@ -34,6 +34,15 @@ def _to_ffmpeg_time(n):
     return '%d:%02d:%09.6f' % (h, m, s)
 
 
+def _to_ffmpeg_codec(codec):
+    ffmpeg_codecs = {
+        'm4a': 'aac',
+        'ogg': 'libvorbis',
+        'wma': 'wmav2',
+    }
+    return ffmpeg_codecs.get(codec) or codec
+
+
 class FFMPEGProcessAudioAdapter(AudioAdapter):
     """ An AudioAdapter implementation that use FFMPEG binary through
     subprocess in order to perform I/O operation for audio processing.
@@ -112,7 +121,7 @@ class FFMPEGProcessAudioAdapter(AudioAdapter):
         if bitrate:
             output_kwargs['audio_bitrate'] = bitrate
         if codec is not None and codec != 'wav':
-            output_kwargs['codec'] = codec
+            output_kwargs['codec'] = _to_ffmpeg_codec(codec)
         process = (
             ffmpeg
             .input('pipe:', format='f32le', **input_kwargs)


### PR DESCRIPTION
# [Spleeter-ffmpeg] - fix unknown encoder error

## Description

Specifying codec `m4a`, `wma` or `ogg` raises Unknown encoder like below.
My env is `python-3.7.dockerfile` .

```
# spleeter separate -i audio_example.mp3 -c m4a

...

Guessed Channel Layout for Input Stream #0.0 : stereo\nInput #0, f32le, from 'pipe:':
  Duration: N/A, bitrate: 2822 kb/s
    Stream #0:0: Audio: pcm_f32le, 44100 Hz, stereo, flt, 2822 kb/s
Unknown encoder 'm4a'"
```

Full formatted error

<details>

```
spleeter separate -i audio_example.mp3 -c m4a
INFO:spleeter:Downloading model archive https://github.com/deezer/spleeter/releases/download/v1.4.0/2stems.tar.gz
INFO:spleeter:Validating archive checksum
INFO:spleeter:Extracting downloaded 2stems archive
INFO:spleeter:2stems model file(s) extracted
ERROR:spleeter:FFMPEG error: b"
ffmpeg version 4.1.4-1~deb10u1 Copyright (c) 2000-2019 the FFmpeg developers
  built with gcc 8 (Debian 8.3.0-6)
  configuration: --prefix=/usr --extra-version='1~deb10u1' --toolchain=hardened --libdir=/usr/lib/x86_64-linux-gnu --incdir=/usr/include/x86_64-linux-gnu --arch=amd64 --enable-gpl --disable-stripping --enable-avresample --disable-filter=resample --enable-avisynth --enable-gnutls --enable-ladspa --enable-libaom --enable-libass --enable-libbluray --enable-libbs2b --enable-libcaca --enable-libcdio --enable-libcodec2 --enable-libflite --enable-libfontconfig --enable-libfreetype --enable-libfribidi --enable-libgme --enable-libgsm --enable-libjack --enable-libmp3lame --enable-libmysofa --enable-libopenjpeg --enable-libopenmpt --enable-libopus --enable-libpulse --enable-librsvg --enable-librubberband --enable-libshine --enable-libsnappy --enable-libsoxr --enable-libspeex --enable-libssh --enable-libtheora --enable-libtwolame --enable-libvidstab --enable-libvorbis --enable-libvpx --enable-libwavpack --enable-libwebp --enable-libx265 --enable-libxml2 --enable-libxvid --enable-libzmq --enable-libzvbi --enable-lv2 --enable-omx --enable-openal --enable-opengl --enable-sdl2 --enable-libdc1394 --enable-libdrm --enable-libiec61883 --enable-chromaprint --enable-frei0r --enable-libx264 --enable-shared
  libavutil      56. 22.100 / 56. 22.100
  libavcodec     58. 35.100 / 58. 35.100
  libavformat    58. 20.100 / 58. 20.100
  libavdevice    58.  5.100 / 58.  5.100
  libavfilter     7. 40.101 /  7. 40.101
  libavresample   4.  0.  0 /  4.  0.  0
  libswscale      5.  3.100 /  5.  3.100
  libswresample   3.  3.100 /  3.  3.100
  libpostproc    55.  3.100 / 55.  3.100
Guessed Channel Layout for Input Stream #0.0 : stereo
Input #0, f32le, from 'pipe:':
  Duration: N/A, bitrate: 2822 kb/s
    Stream #0:0: Audio: pcm_f32le, 44100 Hz, stereo, flt, 2822 kb/s
Unknown encoder 'm4a'
"
```

</details>

## How this patch was tested

executed commands.

`spleeter separate -i audio_example.mp3 -c m4a`
`spleeter separate -i audio_example.mp3 -c wma`
`spleeter separate -i audio_example.mp3 -c ogg`

## Documentation link and external references

Please provide any info that may help us better understand your code.
