### PR TITLE
fix: switch up to 1.4.9

### DIFF
--- a/docker/conda-gpu.dockerfile
+++ b/docker/conda-gpu.dockerfile
@@ -17,7 +17,7 @@ COPY audio_example.mp3 .
 
 RUN conda install -y -c conda-forge musdb
 # RUN conda install -y -c conda-forge museval
-RUN conda install -y -c conda-forge spleeter-gpu=1.4.5
+RUN conda install -y -c conda-forge spleeter-gpu=1.4.9
 
 
 ENTRYPOINT ["spleeter"]

--- a/docker/conda.dockerfile
+++ b/docker/conda.dockerfile
@@ -6,6 +6,6 @@ COPY audio_example.mp3 .
 
 RUN conda install -y -c conda-forge musdb
 # RUN conda install -y -c conda-forge museval
-RUN conda install -y -c conda-forge spleeter=1.4.5
+RUN conda install -y -c conda-forge spleeter=1.4.9
 
 ENTRYPOINT ["spleeter"]

--- a/docker/python-3.6-gpu.dockerfile
+++ b/docker/python-3.6-gpu.dockerfile
@@ -52,6 +52,6 @@ COPY audio_example.mp3 .
 # Spleeter installation.
 RUN apt-get update && apt-get install -y ffmpeg libsndfile1
 RUN pip install musdb museval
-RUN pip install spleeter-gpu==1.4.5
+RUN pip install spleeter-gpu==1.4.9
 
 ENTRYPOINT ["spleeter"]

--- a/docker/python-3.6.dockerfile
+++ b/docker/python-3.6.dockerfile
@@ -6,6 +6,6 @@ COPY audio_example.mp3 .
 
 RUN apt-get update && apt-get install -y ffmpeg libsndfile1
 RUN pip install musdb museval
-RUN pip install spleeter==1.4.5
+RUN pip install spleeter==1.4.9
 
 ENTRYPOINT ["spleeter"]

--- a/docker/python-3.7-gpu.dockerfile
+++ b/docker/python-3.7-gpu.dockerfile
@@ -52,6 +52,6 @@ COPY audio_example.mp3 .
 # Spleeter installation.
 RUN apt-get update && apt-get install -y ffmpeg libsndfile1
 RUN pip install musdb museval
-RUN pip install spleeter-gpu==1.4.5
+RUN pip install spleeter-gpu==1.4.9
 
 ENTRYPOINT ["spleeter"]

--- a/docker/python-3.7.dockerfile
+++ b/docker/python-3.7.dockerfile
@@ -6,6 +6,6 @@ COPY audio_example.mp3 .
 
 RUN apt-get update && apt-get install -y ffmpeg libsndfile1
 RUN pip install musdb museval
-RUN pip install spleeter==1.4.5
+RUN pip install spleeter==1.4.9
 
 ENTRYPOINT ["spleeter"]


### PR DESCRIPTION
# [Spleeter-docker] - fix: switch up to 1.4.9

## Description

update spleeter from 1.4.5.

## How this patch was tested

docker build and exec separate command.

## Documentation link and external references

https://github.com/deezer/spleeter/commit/0ba6c321ce1f96cf84e3ecfcc154b8ab7ba1a56f
