### PR TITLE
Add an option allowing use without a multiprocessing pool

### DIFF
--- a/spleeter/separator.py
+++ b/spleeter/separator.py
@@ -35,7 +35,7 @@ __license__ = 'MIT License'
 class Separator(object):
     """ A wrapper class for performing separation. """
 
-    def __init__(self, params_descriptor, MWF=False):
+    def __init__(self, params_descriptor, MWF=False, multiprocess=True):
         """ Default constructor.
 
         :param params_descriptor: Descriptor for TF params to be used.
@@ -45,7 +45,7 @@ class Separator(object):
         self._sample_rate = self._params['sample_rate']
         self._MWF = MWF
         self._predictor = None
-        self._pool = Pool()
+        self._pool = Pool() if multiprocess else None
         self._tasks = []
 
     def _get_predictor(self):
@@ -133,12 +133,15 @@ class Separator(object):
                     f'Separated source path conflict : {path},'
                     'please check your filename format'))
             generated.append(path)
-            task = self._pool.apply_async(audio_adapter.save, (
-                path,
-                data,
-                self._sample_rate,
-                codec,
-                bitrate))
-            self._tasks.append(task)
-        if synchronous:
+            if self._pool:
+                task = self._pool.apply_async(audio_adapter.save, (
+                    path,
+                    data,
+                    self._sample_rate,
+                    codec,
+                    bitrate))
+                self._tasks.append(task)
+            else:
+                audio_adapter.save(path, data, self._sample_rate, codec, bitrate)
+        if synchronous and self._pool:
             self.join()


### PR DESCRIPTION
# [Spleeter] - Add an option allowing use without a multiprocessing pool

This PR adds a keyword argument allowing a `Separator` to be used asynchronously within a `multiprocessing`-created subprocess (by bypassing its `multiprocessing.Pool` and doing its work in the main process). Without this option enabled, attempting to do so will fail with an error "AssertionError: daemonic processes are not allowed to have children."

## How this patch was tested

I'm working on a tool that calls `separate_to_file` using `Pool.apply_async`. Prior to this patch it failed with the AssertionError above. After applying the patch and passing `multiprocess=False` to the `Separator` constructor the separation works as expected.

## Documentation link and external references

Info about the exception in the Python docs: https://docs.python.org/3/library/multiprocessing.html#multiprocessing.Process.daemon

Here's a SO example of someone encountering the same exception in a similar scenario: https://stackoverflow.com/questions/51485212/multiprocessing-gives-assertionerror-daemonic-processes-are-not-allowed-to-have

It seems that this problem could also be avoided by using a `ThreadPool` but I understand spleeter to be fairly CPU-bound so threads aren't a great solution. However if spleeter does most of its heavy lifting in its own subprocesses, it might work to use a `ThreadPool` instead. I'm willing to try it if you'd prefer.