### PR TITLE
fix typo

### DIFF
--- a/spleeter/audio/ffmpeg.py
+++ b/spleeter/audio/ffmpeg.py
@@ -134,4 +134,4 @@ class FFMPEGProcessAudioAdapter(AudioAdapter):
             process.wait()
         except IOError:
             raise SpleeterError(f'FFMPEG error: {process.stderr.read()}')
-        get_logger().info('File %s written succesfully', path)
+        get_logger().info('File %s written successfully', path)


### PR DESCRIPTION
# [Spleeter-N/A] - fix typo

## Description

This PR fixes a simple typo: "succesfully" -> "successfully"

## How this patch was tested

I looked at the diff, it's obviously correct. :wink:  

## Documentation link and external references

I'm not going to link a dictionary. *\*does the wiggly eyebrow thing\**