### PR TITLE
Fix typo infered -> inferred

### DIFF
--- a/spleeter/audio/ffmpeg.py
+++ b/spleeter/audio/ffmpeg.py
@@ -48,7 +48,7 @@ class FFMPEGProcessAudioAdapter(AudioAdapter):
     subprocess in order to perform I/O operation for audio processing.
 
     When created, FFMPEG binary path will be checked and expended,
-    raising exception if not found. Such path could be infered using
+    raising exception if not found. Such path could be inferred using
     FFMPEG_PATH environment variable.
     """
 


### PR DESCRIPTION
# [Spleeter-N/A] - Fix typo infered -> inferred

## Description

See title

## How this patch was tested

Testing is not needed, as this is a docstring update only.

## Documentation link and external references

https://en.wikipedia.org/wiki/Wikipedia:Lists_of_common_misspellings/For_machines