### PR TITLE
Librosa backend

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pandas==0.25.1
 tensorflow==1.14.0
 ffmpeg-python
 norbert==0.2.1
+librosa==0.7.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ importlib_resources; python_version<'3.7'
 requests
 setuptools>=41.0.0
 pandas==0.25.1
-tensorflow==1.14.0
+tensorflow==1.15.0
 ffmpeg-python
 norbert==0.2.1
 librosa==0.7.2

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ __license__ = 'MIT License'
 
 # Default project values.
 project_name = 'spleeter'
-project_version = '1.4.9'
+project_version = '1.5.0'
 tensorflow_dependency = 'tensorflow'
 tensorflow_version = '1.14.0'
 here = path.abspath(path.dirname(__file__))
@@ -56,6 +56,7 @@ setup(
         'pandas==0.25.1',
         'requests',
         'setuptools>=41.0.0',
+        'librosa==0.7.2',
         '{}=={}'.format(tensorflow_dependency, tensorflow_version),
     ],
     extras_require={

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ __license__ = 'MIT License'
 project_name = 'spleeter'
 project_version = '1.5.0'
 tensorflow_dependency = 'tensorflow'
-tensorflow_version = '1.14.0'
+tensorflow_version = '1.15.0'
 here = path.abspath(path.dirname(__file__))
 readme_path = path.join(here, 'README.md')
 with open(readme_path, 'r') as stream:

--- a/spleeter/commands/__init__.py
+++ b/spleeter/commands/__init__.py
@@ -72,14 +72,13 @@ OPT_DURATION = {
 }
 
 # -w opt specification (separate)
-OPT_CHUNKED = {
-    'dest': 'chunk_duration',
-    'type': float,
-    'default': -1,
-    'help': 'Maximum duration of the segments that are fed to'
-            ' the network. Use this parameter to limit '
-            'memory usage. Use -1 to process the whole signal'
-            ' in one pass.'
+OPT_STFT_BACKEND = {
+    'dest': 'stft_backend',
+    'type': str,
+    'choices' : ["tensorflow", "librosa", "auto"],
+    'default': "auto",
+    'help': 'Who should be in charge of computing the stfts. Librosa is faster than tensorflow on CPU and uses'
+            ' less memory. "auto" will use tensorflow when GPU acceleration is available and librosa when not.'
 }
 
 
@@ -191,7 +190,7 @@ def _create_separate_parser(parser_factory):
     parser.add_argument('-c', '--codec', **OPT_CODEC)
     parser.add_argument('-b', '--birate', **OPT_BITRATE)
     parser.add_argument('-m', '--mwf', **OPT_MWF)
-    parser.add_argument('-w', '--chunk', **OPT_CHUNKED)
+    parser.add_argument('-B', '--stft-backend', **OPT_STFT_BACKEND)
     return parser
 
 

--- a/spleeter/commands/__init__.py
+++ b/spleeter/commands/__init__.py
@@ -13,7 +13,6 @@ __email__ = 'research@deezer.com'
 __author__ = 'Deezer Research'
 __license__ = 'MIT License'
 
-logging.basicConfig()
 
 
 # -i opt specification (separate).

--- a/spleeter/commands/__init__.py
+++ b/spleeter/commands/__init__.py
@@ -4,7 +4,7 @@
 """ This modules provides spleeter command as well as CLI parsing methods. """
 
 import json
-
+import logging
 from argparse import ArgumentParser
 from tempfile import gettempdir
 from os.path import exists, join
@@ -12,6 +12,9 @@ from os.path import exists, join
 __email__ = 'research@deezer.com'
 __author__ = 'Deezer Research'
 __license__ = 'MIT License'
+
+logging.basicConfig()
+
 
 # -i opt specification (separate).
 OPT_INPUT = {

--- a/spleeter/commands/__init__.py
+++ b/spleeter/commands/__init__.py
@@ -68,6 +68,18 @@ OPT_DURATION = {
         'the input file)')
 }
 
+# -w opt specification (separate)
+OPT_CHUNKED = {
+    'dest': 'chunk_duration',
+    'type': float,
+    'default': -1,
+    'help': 'Maximum duration of the segments that are fed to'
+            ' the network. Use this parameter to limit '
+            'memory usage. Use -1 to process the whole signal'
+            ' in one pass.'
+}
+
+
 # -c opt specification (separate).
 OPT_CODEC = {
     'dest': 'codec',
@@ -176,6 +188,7 @@ def _create_separate_parser(parser_factory):
     parser.add_argument('-c', '--codec', **OPT_CODEC)
     parser.add_argument('-b', '--birate', **OPT_BITRATE)
     parser.add_argument('-m', '--mwf', **OPT_MWF)
+    parser.add_argument('-w', '--chunk', **OPT_CHUNKED)
     return parser
 
 

--- a/spleeter/commands/separate.py
+++ b/spleeter/commands/separate.py
@@ -35,6 +35,7 @@ def entrypoint(arguments, params):
             filename,
             arguments.output_path,
             audio_adapter=audio_adapter,
+            chunk_duration=arguments.chunk_duration,
             offset=arguments.offset,
             duration=arguments.duration,
             codec=arguments.codec,

--- a/spleeter/commands/separate.py
+++ b/spleeter/commands/separate.py
@@ -11,12 +11,20 @@
         -i /path/to/audio1.wav /path/to/audio2.mp3
 """
 
+import tensorflow as tf
+
 from ..audio.adapter import get_audio_adapter
 from ..separator import Separator
 
 __email__ = 'research@deezer.com'
 __author__ = 'Deezer Research'
 __license__ = 'MIT License'
+
+
+def get_backend(backend):
+    if backend == "auto":
+        return "tensorflow" if tf.test.is_gpu_available() else "librosa"
+    return backend
 
 
 def entrypoint(arguments, params):
@@ -29,13 +37,13 @@ def entrypoint(arguments, params):
     audio_adapter = get_audio_adapter(arguments.audio_adapter)
     separator = Separator(
         arguments.configuration,
-        arguments.MWF)
+        MWF=arguments.MWF,
+        stft_backend=get_backend(arguments.stft_backend))
     for filename in arguments.inputs:
         separator.separate_to_file(
             filename,
             arguments.output_path,
             audio_adapter=audio_adapter,
-            chunk_duration=arguments.chunk_duration,
             offset=arguments.offset,
             duration=arguments.duration,
             codec=arguments.codec,

--- a/spleeter/commands/separate.py
+++ b/spleeter/commands/separate.py
@@ -11,8 +11,6 @@
         -i /path/to/audio1.wav /path/to/audio2.mp3
 """
 
-import tensorflow as tf
-
 from ..audio.adapter import get_audio_adapter
 from ..separator import Separator
 
@@ -20,11 +18,6 @@ __email__ = 'research@deezer.com'
 __author__ = 'Deezer Research'
 __license__ = 'MIT License'
 
-
-def get_backend(backend):
-    if backend == "auto":
-        return "tensorflow" if tf.test.is_gpu_available() else "librosa"
-    return backend
 
 
 def entrypoint(arguments, params):
@@ -38,7 +31,7 @@ def entrypoint(arguments, params):
     separator = Separator(
         arguments.configuration,
         MWF=arguments.MWF,
-        stft_backend=get_backend(arguments.stft_backend))
+        stft_backend=arguments.stft_backend)
     for filename in arguments.inputs:
         separator.separate_to_file(
             filename,

--- a/spleeter/model/__init__.py
+++ b/spleeter/model/__init__.py
@@ -18,7 +18,6 @@ __author__ = 'Deezer Research'
 __license__ = 'MIT License'
 
 
-
 placeholder = tf.compat.v1.placeholder
 
 
@@ -326,14 +325,14 @@ class EstimatorSpecBuilder(object):
             self._build_masked_stfts()
         return self._masked_stfts
 
-    def _inverse_stft(self, stft, time_crop=None):
+    def _inverse_stft(self, stft_t, time_crop=None):
         """ Inverse and reshape the given STFT
 
-        :param stft: input STFT
+        :param stft_t: input STFT
         :returns: inverse STFT (waveform)
         """
         inversed = inverse_stft(
-            tf.transpose(stft, perm=[2, 0, 1]),
+            tf.transpose(stft_t, perm=[2, 0, 1]),
             self._frame_length,
             self._frame_step,
             window_fn=lambda frame_length, dtype: (
@@ -419,7 +418,7 @@ class EstimatorSpecBuilder(object):
             output = output_dict[f'{instrument}_spectrogram']
             # Compute mask with the model.
             instrument_mask = (output ** separation_exponent
-                                      + (self.EPSILON / len(output_dict))) / output_sum
+                               + (self.EPSILON / len(output_dict))) / output_sum
             # Extend mask;
             instrument_mask = self._extend_mask(instrument_mask)
             # Stack back mask.

--- a/spleeter/model/__init__.py
+++ b/spleeter/model/__init__.py
@@ -105,7 +105,7 @@ class InputProviderFactory(object):
     @staticmethod
     def get(params):
         stft_backend = params["stft_backend"]
-        assert stft_backend in ("tensorflow", "librosa")
+        assert stft_backend in ("tensorflow", "librosa"), "Unexpected backend {}".format(stft_backend)
         if stft_backend == "tensorflow":
             return WaveformInputProvider(params)
         else:

--- a/spleeter/model/__init__.py
+++ b/spleeter/model/__init__.py
@@ -18,6 +18,10 @@ __author__ = 'Deezer Research'
 __license__ = 'MIT License'
 
 
+
+placeholder = tf.compat.v1.placeholder
+
+
 def get_model_function(model_type):
     """
         Get tensorflow function of the model to be applied to the input tensor.
@@ -41,6 +45,74 @@ def get_model_function(model_type):
     return model_function
 
 
+class InputProvider(object):
+
+    def __init__(self, params):
+        self.params = params
+
+    def get_input_dict_placeholders(self):
+        raise NotImplementedError()
+
+    @property
+    def input_names(self):
+        raise NotImplementedError()
+
+    def get_feed_dict(self, features, *args):
+        raise NotImplementedError()
+
+
+class WaveformInputProvider(InputProvider):
+
+    @property
+    def input_names(self):
+        return ["audio_id", "waveform"]
+
+    def get_input_dict_placeholders(self):
+        shape = (None, self.params['n_channels'])
+        features = {
+            'waveform': placeholder(tf.float32, shape=shape, name="waveform"),
+            'audio_id': placeholder(tf.string, name="audio_id")}
+        return features
+
+    def get_feed_dict(self, features, waveform, audio_id):
+        return {features["audio_id"]: audio_id, features["waveform"]: waveform}
+
+
+class SpectralInputProvider(InputProvider):
+
+    def __init__(self, params):
+        super().__init__(params)
+        self.stft_input_name = "{}_stft".format(self.params["mix_name"])
+
+    @property
+    def input_names(self):
+        return ["audio_id", self.stft_input_name]
+
+    def get_input_dict_placeholders(self):
+        features = {
+            self.stft_input_name: placeholder(tf.complex64,
+                                              shape=(None, self.params["frame_length"]//2+1,
+                                                     self.params['n_channels']),
+                                              name=self.stft_input_name),
+            'audio_id': placeholder(tf.string, name="audio_id")}
+        return features
+
+    def get_feed_dict(self, features, stft, audio_id):
+        return {features["audio_id"]: audio_id, features[self.stft_input_name]: stft}
+
+
+class InputProviderFactory(object):
+
+    @staticmethod
+    def get(params):
+        stft_backend = params["stft_backend"]
+        assert stft_backend in ("tensorflow", "librosa")
+        if stft_backend == "tensorflow":
+            return WaveformInputProvider(params)
+        else:
+            return SpectralInputProvider(params)
+
+
 class EstimatorSpecBuilder(object):
     """ A builder class that allows to builds a multitrack unet model
     estimator. The built model estimator has a different behaviour when
@@ -57,9 +129,9 @@ class EstimatorSpecBuilder(object):
 
     >>> from spleeter.model import EstimatorSpecBuilder
     >>> builder = EstimatorSpecBuilder()
-    >>> builder.build_prediction_model()
+    >>> builder.build_predict_model()
     >>> builder.build_evaluation_model()
-    >>> builder.build_training_model()
+    >>> builder.build_train_model()
 
     >>> from spleeter.model import model_fn
     >>> estimator = tf.estimator.Estimator(model_fn=model_fn, ...)
@@ -94,6 +166,7 @@ class EstimatorSpecBuilder(object):
         :param features: The input features for the estimator.
         :param params: Some hyperparameters as a dictionary.
         """
+
         self._features = features
         self._params = params
         # Get instrument name.
@@ -106,7 +179,10 @@ class EstimatorSpecBuilder(object):
         self._frame_length = params['frame_length']
         self._frame_step = params['frame_step']
 
-    def _build_output_dict(self, input_tensor=None):
+    def include_stft_computations(self):
+        return self._params["stft_backend"] == "tensorflow"
+
+    def _build_model_outputs(self):
         """ Created a batch_sizexTxFxn_channels input tensor containing
         mix magnitude spectrogram, then an output dict from it according
         to the selected model in internal parameters.
@@ -114,8 +190,8 @@ class EstimatorSpecBuilder(object):
         :returns: Build output dict.
         :raise ValueError: If required model_type is not supported.
         """
-        if input_tensor is None:
-            input_tensor = self._features[f'{self._mix_name}_spectrogram']
+
+        input_tensor = self.spectrogram_feature
         model = self._params.get('model', None)
         if model is not None:
             model_type = model.get('type', self.DEFAULT_MODEL)
@@ -125,12 +201,12 @@ class EstimatorSpecBuilder(object):
             apply_model = get_model_function(model_type)
         except ModuleNotFoundError:
             raise ValueError(f'No model function {model_type} found')
-        return apply_model(
+        self._model_outputs = apply_model(
             input_tensor,
             self._instruments,
             self._params['model']['params'])
 
-    def _build_loss(self, output_dict, labels):
+    def _build_loss(self, labels):
         """ Construct tensorflow loss and metrics
 
         :param output_dict: dictionary of network outputs (key: instrument
@@ -139,6 +215,7 @@ class EstimatorSpecBuilder(object):
             name, value: ground truth spectrogram of the instrument)
         :returns: tensorflow (loss, metrics) tuple.
         """
+        output_dict = self.model_outputs
         loss_type = self._params.get('loss_type', self.L1_MASK)
         if loss_type == self.L1_MASK:
             losses = {
@@ -178,30 +255,72 @@ class EstimatorSpecBuilder(object):
             return tf.compat.v1.train.GradientDescentOptimizer(rate)
         return tf.compat.v1.train.AdamOptimizer(rate)
 
+    @property
+    def instruments(self):
+        return self._instruments
+
+    @property
+    def stft_name(self):
+        return f'{self._mix_name}_stft'
+
+    @property
+    def spectrogram_name(self):
+        return f'{self._mix_name}_spectrogram'
+
     def _build_stft_feature(self):
         """ Compute STFT of waveform and slice the STFT in segment
          with the right length to feed the network.
         """
-        stft_feature = tf.transpose(
-            stft(
-                tf.transpose(self._features['waveform']),
-                self._frame_length,
-                self._frame_step,
-                window_fn=lambda frame_length, dtype: (
-                    hann_window(frame_length, periodic=True, dtype=dtype)),
-                pad_end=True),
-            perm=[1, 2, 0])
-        self._features[f'{self._mix_name}_stft'] = stft_feature
-        self._features[f'{self._mix_name}_spectrogram'] = tf.abs(
-            pad_and_partition(stft_feature, self._T))[:, :, :self._F, :]
 
-    def get_stft_feature(self):
-        return self._features[f'{self._mix_name}_stft']
+        stft_name = self.stft_name
+        spec_name = self.spectrogram_name
 
-    def get_spectrogram_feature(self):
-        return self._features[f'{self._mix_name}_spectrogram']
+        if stft_name not in self._features:
+            stft_feature = tf.transpose(
+                stft(
+                    tf.transpose(self._features['waveform']),
+                    self._frame_length,
+                    self._frame_step,
+                    window_fn=lambda frame_length, dtype: (
+                        hann_window(frame_length, periodic=True, dtype=dtype)),
+                    pad_end=True),
+                perm=[1, 2, 0])
+            self._features[f'{self._mix_name}_stft'] = stft_feature
+        if spec_name not in self._features:
+            self._features[spec_name] = tf.abs(
+                pad_and_partition(self._features[stft_name], self._T))[:, :, :self._F, :]
 
-    def _inverse_stft(self, stft):
+    @property
+    def model_outputs(self):
+        if not hasattr(self, "_model_outputs"):
+            self._build_model_outputs()
+        return self._model_outputs
+
+    @property
+    def outputs(self):
+        if not hasattr(self, "_outputs"):
+            self._build_outputs()
+        return self._outputs
+
+    @property
+    def stft_feature(self):
+        if self.stft_name not in self._features:
+            self._build_stft_feature()
+        return self._features[self.stft_name]
+
+    @property
+    def spectrogram_feature(self):
+        if self.spectrogram_name not in self._features:
+            self._build_stft_feature()
+        return self._features[self.spectrogram_name]
+
+    @property
+    def masks(self):
+        if not hasattr(self, "_masks"):
+            self._build_masks()
+        return self._masks
+
+    def _inverse_stft(self, stft, time_crop=None):
         """ Inverse and reshape the given STFT
 
         :param stft: input STFT
@@ -215,20 +334,21 @@ class EstimatorSpecBuilder(object):
                 hann_window(frame_length, periodic=True, dtype=dtype))
         ) * self.WINDOW_COMPENSATION_FACTOR
         reshaped = tf.transpose(inversed)
-        return reshaped[:tf.shape(self._features['waveform'])[0], :]
+        if time_crop is None:
+            time_crop = tf.shape(self._features['waveform'])[0]
+        return reshaped[:time_crop, :]
 
-    def _build_mwf_output_waveform(self, output_dict):
+    def _build_mwf_output_waveform(self):
         """ Perform separation with multichannel Wiener Filtering using Norbert.
         Note: multichannel Wiener Filtering is not coded in Tensorflow and thus
         may be quite slow.
 
-        :param output_dict: dictionary of estimated spectrogram (key: instrument
-            name, value: estimated spectrogram of the instrument)
         :returns: dictionary of separated waveforms (key: instrument name,
             value: estimated waveform of the instrument)
         """
         import norbert  # pylint: disable=import-error
-        x = self._features[f'{self._mix_name}_stft']
+        output_dict = self.model_outputs
+        x = self.stft_feature
         v = tf.stack(
             [
                 pad_and_reshape(
@@ -272,11 +392,13 @@ class EstimatorSpecBuilder(object):
                 mask_shape[-1]))
         else:
             raise ValueError(f'Invalid mask_extension parameter {extension}')
-        n_extra_row = (self._frame_length) // 2 + 1 - self._F
+        n_extra_row = self._frame_length // 2 + 1 - self._F
         extension = tf.tile(extension_row, [1, 1, n_extra_row, 1])
         return tf.concat([mask, extension], axis=2)
 
-    def _build_masks(self, output_dict):
+    def _build_masks(self):
+        output_dict = self.model_outputs
+        stft_feature = self.stft_feature
         separation_exponent = self._params['separation_exponent']
         output_sum = tf.reduce_sum(
             [e ** separation_exponent for e in output_dict.values()],
@@ -297,21 +419,20 @@ class EstimatorSpecBuilder(object):
                 axis=0)
             instrument_mask = tf.reshape(instrument_mask, new_shape)
             # Remove padded part (for mask having the same size as STFT);
-            stft_feature = self._features[f'{self._mix_name}_stft']
+
             instrument_mask = instrument_mask[
                               :tf.shape(stft_feature)[0], ...]
             out[instrument] = instrument_mask
-        return out
+        self._masks = out
 
-    def _build_masked_stft(self, mask_dict, input_stft=None):
-        if input_stft is None:
-            input_stft = self._features[f'{self._mix_name}_stft']
+    def _build_masked_stft(self):
+        input_stft = self.stft_feature
         out = {}
-        for instrument, mask in mask_dict.items():
+        for instrument, mask in self.masks.items():
             out[instrument] = tf.cast(mask, dtype=tf.complex64) * input_stft
         return out
 
-    def _build_manual_output_waveform(self, output_dict):
+    def _build_manual_output_waveform(self, masked_stft):
         """ Perform ratio mask separation
 
         :param output_dict: dictionary of estimated spectrogram (key: instrument
@@ -321,26 +442,33 @@ class EstimatorSpecBuilder(object):
         """
 
         output_waveform = {}
-        masked_stft = self._build_masked_stft(self._build_masks(output_dict))
         for instrument, stft_data in masked_stft.items():
             output_waveform[instrument] = self._inverse_stft(stft_data)
         return output_waveform
 
-    def _build_output_waveform(self, output_dict):
+    def _build_output_waveform(self, masked_stft):
         """ Build output waveform from given output dict in order to be used in
         prediction context. Regarding of the configuration building method will
         be using MWF.
 
-        :param output_dict: Output dict to build output waveform from.
         :returns: Built output waveform.
         """
+
         if self._params.get('MWF', False):
-            output_waveform = self._build_mwf_output_waveform(output_dict)
+            output_waveform = self._build_mwf_output_waveform()
         else:
-            output_waveform = self._build_manual_output_waveform(output_dict)
-        if 'audio_id' in self._features:
-            output_waveform['audio_id'] = self._features['audio_id']
+            output_waveform = self._build_manual_output_waveform(masked_stft)
         return output_waveform
+
+    def _build_outputs(self):
+        masked_stft = self._build_masked_stft()
+        if self.include_stft_computations():
+            self._outputs = self._build_output_waveform(masked_stft)
+        else:
+            self._outputs = masked_stft
+
+        if 'audio_id' in self._features:
+            self._outputs['audio_id'] = self._features['audio_id']
 
     def build_predict_model(self):
         """ Builder interface for creating model instance that aims to perform
@@ -350,12 +478,10 @@ class EstimatorSpecBuilder(object):
 
         :returns: An estimator for performing prediction.
         """
-        self._build_stft_feature()
-        output_dict = self._build_output_dict()
-        output_waveform = self._build_output_waveform(output_dict)
+
         return tf.estimator.EstimatorSpec(
             tf.estimator.ModeKeys.PREDICT,
-            predictions=output_waveform)
+            predictions=self.outputs)
 
     def build_evaluation_model(self, labels):
         """ Builder interface for creating model instance that aims to perform
@@ -366,8 +492,7 @@ class EstimatorSpecBuilder(object):
         :param labels: Model labels.
         :returns: An estimator for performing model evaluation.
         """
-        output_dict = self._build_output_dict()
-        loss, metrics = self._build_loss(output_dict, labels)
+        loss, metrics = self._build_loss(labels)
         return tf.estimator.EstimatorSpec(
             tf.estimator.ModeKeys.EVAL,
             loss=loss,
@@ -382,8 +507,7 @@ class EstimatorSpecBuilder(object):
         :param labels: Model labels.
         :returns: An estimator for performing model training.
         """
-        output_dict = self._build_output_dict()
-        loss, metrics = self._build_loss(output_dict, labels)
+        loss, metrics = self._build_loss(labels)
         optimizer = self._build_optimizer()
         train_operation = optimizer.minimize(
                 loss=loss,

--- a/spleeter/separator.py
+++ b/spleeter/separator.py
@@ -98,30 +98,6 @@ class Separator(object):
         prediction.pop('audio_id')
         return prediction
 
-    def get_valid_chunk_size(self, sample_rate: int, chunk_max_duration: float) -> int:
-        """
-        Given a sample rate, and a maximal duration that a chunk can represent, return the maximum chunk
-        size in samples. The chunk size must be a non-zero multiple of T (temporal dimension of the input spectrogram)
-        times F (number of frequency bins in the input spectrogram). If no such value exist, we return T*F.
-
-        :param sample_rate:         sample rate of the pcm data
-        :param chunk_max_duration:  maximal duration in seconds of a chunk
-        :return: highest non-zero chunk size of duration less than chunk_max_duration or minimal valid chunk size.
-        """
-        assert chunk_max_duration > 0
-        chunk_size = chunk_max_duration * sample_rate
-        min_sample_size = self._params["T"] * self._params["F"]
-        if chunk_size < min_sample_size:
-            min_duration = min_sample_size / sample_rate
-            logger.warning("chunk_duration must be at least {:.2f} seconds. Ignoring parameter".format(min_duration))
-            chunk_size = min_sample_size
-        return min_sample_size*int(chunk_size/min_sample_size)
-
-    def get_batch_size_for_chunk_size(self, chunk_size):
-        d = self._params["T"] * self._params["F"]
-        assert chunk_size % d == 0
-        return chunk_size//d
-
     def stft(self, waveform, inverse=False):
         N = self._params["frame_length"]
         H = self._params["frame_step"]

--- a/spleeter/separator.py
+++ b/spleeter/separator.py
@@ -39,6 +39,14 @@ __license__ = 'MIT License'
 logger = logging.getLogger("spleeter")
 
 
+
+def get_backend(backend):
+    assert backend in ["auto", "tensorflow", "librosa"]
+    if backend == "auto":
+        return "tensorflow" if tf.test.is_gpu_available() else "librosa"
+    return backend
+
+
 class Separator(object):
     """ A wrapper class for performing separation. """
 
@@ -48,13 +56,14 @@ class Separator(object):
         :param params_descriptor: Descriptor for TF params to be used.
         :param MWF: (Optional) True if MWF should be used, False otherwise.
         """
+
         self._params = load_configuration(params_descriptor)
         self._sample_rate = self._params['sample_rate']
         self._MWF = MWF
         self._predictor = None
         self._pool = Pool() if multiprocess else None
         self._tasks = []
-        self._params["stft_backend"] = stft_backend
+        self._params["stft_backend"] = get_backend(stft_backend)
 
     def _get_predictor(self):
         """ Lazy loading access method for internal predictor instance.

--- a/tests/test_separator.py
+++ b/tests/test_separator.py
@@ -13,6 +13,7 @@ from os.path import splitext, basename, exists, join
 from tempfile import TemporaryDirectory
 
 import pytest
+import numpy as np
 
 from spleeter import SpleeterError
 from spleeter.audio.adapter import get_default_audio_adapter
@@ -21,34 +22,38 @@ from spleeter.separator import Separator
 TEST_AUDIO_DESCRIPTOR = 'audio_example.mp3'
 TEST_AUDIO_BASENAME = splitext(basename(TEST_AUDIO_DESCRIPTOR))[0]
 TEST_CONFIGURATIONS = [
-    ('spleeter:2stems', ('vocals', 'accompaniment')),
-    ('spleeter:4stems', ('vocals', 'drums', 'bass', 'other')),
-    ('spleeter:5stems', ('vocals', 'drums', 'bass', 'piano', 'other'))
+    ('spleeter:2stems', ('vocals', 'accompaniment'), 'tensorflow'),
+    ('spleeter:4stems', ('vocals', 'drums', 'bass', 'other'), 'tensorflow'),
+    ('spleeter:5stems', ('vocals', 'drums', 'bass', 'piano', 'other'), 'tensorflow'),
+    ('spleeter:2stems', ('vocals', 'accompaniment'), 'librosa'),
+    ('spleeter:4stems', ('vocals', 'drums', 'bass', 'other'), 'librosa'),
+    ('spleeter:5stems', ('vocals', 'drums', 'bass', 'piano', 'other'), 'librosa')
 ]
 
 
-@pytest.mark.parametrize('configuration, instruments', TEST_CONFIGURATIONS)
-def test_separate(configuration, instruments):
+@pytest.mark.parametrize('configuration, instruments, backend', TEST_CONFIGURATIONS)
+def test_separate(configuration, instruments, backend):
     """ Test separation from raw data. """
     adapter = get_default_audio_adapter()
     waveform, _ = adapter.load(TEST_AUDIO_DESCRIPTOR)
-    separator = Separator(configuration)
-    prediction = separator.separate(waveform)
+    separator = Separator(configuration, stft_backend=backend)
+    prediction = separator.separate(waveform, TEST_AUDIO_DESCRIPTOR)
     assert len(prediction) == len(instruments)
     for instrument in instruments:
         assert instrument in prediction
     for instrument in instruments:
         track = prediction[instrument]
-        assert not (waveform == track).all()
+        assert waveform.shape == track.shape
+        assert not np.allclose(waveform, track)
         for compared in instruments:
             if instrument != compared:
-                assert not (track == prediction[compared]).all()
+                assert not np.allclose(track, prediction[compared])
 
 
-@pytest.mark.parametrize('configuration, instruments', TEST_CONFIGURATIONS)
-def test_separate_to_file(configuration, instruments):
+@pytest.mark.parametrize('configuration, instruments, backend', TEST_CONFIGURATIONS)
+def test_separate_to_file(configuration, instruments, backend):
     """ Test file based separation. """
-    separator = Separator(configuration)
+    separator = Separator(configuration, stft_backend=backend)
     with TemporaryDirectory() as directory:
         separator.separate_to_file(
             TEST_AUDIO_DESCRIPTOR,
@@ -59,10 +64,10 @@ def test_separate_to_file(configuration, instruments):
                 '{}/{}.wav'.format(TEST_AUDIO_BASENAME, instrument)))
 
 
-@pytest.mark.parametrize('configuration, instruments', TEST_CONFIGURATIONS)
-def test_filename_format(configuration, instruments):
+@pytest.mark.parametrize('configuration, instruments, backend', TEST_CONFIGURATIONS)
+def test_filename_format(configuration, instruments, backend):
     """ Test custom filename format. """
-    separator = Separator(configuration)
+    separator = Separator(configuration, stft_backend=backend)
     with TemporaryDirectory() as directory:
         separator.separate_to_file(
             TEST_AUDIO_DESCRIPTOR,
@@ -74,7 +79,7 @@ def test_filename_format(configuration, instruments):
                 'export/{}/{}.wav'.format(TEST_AUDIO_BASENAME, instrument)))
 
 
-def test_filename_confilct():
+def test_filename_conflict():
     """ Test error handling with static pattern. """
     separator = Separator(TEST_CONFIGURATIONS[0][0])
     with TemporaryDirectory() as directory:


### PR DESCRIPTION
# [Spleeter-282] - Using librosa as an alternative backend for stft computation

## Description

Tensorflow's implementation of stft and istft on CPU is extremely slow and glutton in memory. I implemented the possibility to defer these computations to librosa which results in faster inference on CPU and vastly diminished memory usage. The use of the backend can be controlled by an additional parameter on the command line, which defaults to the following logic:
- GPU acceleration available -> tensorflow backend for stfts
- GPU acceleration not available -> librosa backend for stfts.

## How this patch was tested

Ran the separate commands using all the different backend options and checked the consistencies of the outputs as well as the memory use.
