### PR TITLE
Cleanup model archive tempfile

### DIFF
--- a/spleeter/model/provider/github.py
+++ b/spleeter/model/provider/github.py
@@ -105,7 +105,6 @@ class GithubModelProvider(ModelProvider):
             if compute_file_checksum(archive.name) != self.checksum(name):
                 raise IOError('Downloaded file is corrupted, please retry')
             get_logger().info('Extracting downloaded %s archive', name)
-            tar = tarfile.open(name=archive.name)
-            tar.extractall(path=path)
-            tar.close()
+            with tarfile.open(name=archive.name) as tar:
+                tar.extractall(path=path)
         get_logger().info('%s model file(s) extracted', name)


### PR DESCRIPTION
# Cleanup model archive tempfile

## Description

This PR deletes the downloaded model archive tempfile after the model files are extracted. Before this change the tempfile would never get deleted even after the process exited.

I noticed this when I was building a docker image that pre-downloaded spleeter models and was surprised that the resulting layer was twice as big as I expected (one copy in `/tmp/` and one in `pretrained_models/`).

## How this patch was tested

I manually tested this by running the code and watching the temporary file get created and deleted.

It didn't seem worth it to write an automated test. The temp filename is only visible in `GithubModelProvider.download()` and refactoring to expose it didn't seem like a good idea. And a test that asserts something like "no new files were created in the temp directory" would sporadically fail if tests are run parallel or on a system doing anything else.