### PR TITLE
Use tf.abs in compute_spectrogram_tf

### DIFF
--- a/spleeter/audio/spectrogram.py
+++ b/spleeter/audio/spectrogram.py
@@ -44,7 +44,7 @@ def compute_spectrogram_tf(
                 periodic=True,
                 dtype=waveform.dtype) ** window_exponent),
         perm=[1, 2, 0])
-    return np.abs(stft_tensor) ** spec_exponent
+    return tf.abs(stft_tensor) ** spec_exponent
 
 
 def time_stretch(


### PR DESCRIPTION
# Use tf.abs in compute_spectrogram_tf

## Description

Use `tf` methods that both consumes and produces a tensor to avoid the following error: `Cannot convert a symbolic Tensor (transpose_1:0) to a numpy array`

Note: How is it possible to run the current code?

## How this patch was tested

Trained a model with MusDB data set.

## Documentation link and external references

N/A
