### PR TITLE
Avoid multiple checkpoint restoration + one tf.graph per Separator

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ __license__ = 'MIT License'
 
 # Default project values.
 project_name = 'spleeter'
-project_version = '1.5.1'
+project_version = '1.5.2'
 tensorflow_dependency = 'tensorflow'
 tensorflow_version = '1.15.2'
 here = path.abspath(path.dirname(__file__))


### PR DESCRIPTION
# [Spleeter] - Avoid multiple checkpoint restauration and add a specific tf graph for each Separator.

## Description

Avoid multiple checkpoint restauration and add a specific tf graph for each Separator when the librosa backend is used. A tensorflow session is also opened in each Separator instance.

Improvements:
- It makes it possible to instantiate several Separators without Errors.
- It avoids restoring models at each separation (which is very slow).
Note: we may release a new version with this fix.

## How this patch was tested

tested with `make test`