### PR TITLE
Fix eval

### DIFF
--- a/spleeter/commands/evaluate.py
+++ b/spleeter/commands/evaluate.py
@@ -70,7 +70,7 @@ def _separate_evaluation_dataset(arguments, musdb_root_directory, params):
             configuration=arguments.configuration,
             inputs=mixtures,
             output_path=join(audio_output_directory, _SPLIT),
-            filename_format='{filename}/{instrument}.{codec}',
+            filename_format='{foldername}/{instrument}.{codec}',
             codec='wav',
             duration=600.,
             offset=0.,

--- a/spleeter/commands/evaluate.py
+++ b/spleeter/commands/evaluate.py
@@ -76,7 +76,8 @@ def _separate_evaluation_dataset(arguments, musdb_root_directory, params):
             offset=0.,
             bitrate='128k',
             MWF=arguments.MWF,
-            verbose=arguments.verbose),
+            verbose=arguments.verbose,
+            stft_backend="auto"),
         params)
     return audio_output_directory
 

--- a/spleeter/separator.py
+++ b/spleeter/separator.py
@@ -17,7 +17,7 @@ import logging
 
 from time import time
 from multiprocessing import Pool
-from os.path import basename, join, splitext
+from os.path import basename, join, splitext, dirname
 import numpy as np
 import tensorflow as tf
 from librosa.core import stft, istft
@@ -204,7 +204,7 @@ class Separator(object):
         given audio adapter.
 
         Filename format should be a Python formattable string that could use
-        following parameters : {instrument}, {filename} and {codec}.
+        following parameters : {instrument}, {filename}, {foldername} and {codec}.
 
         :param audio_descriptor:    Describe song to separate, used by audio
                                     adapter to retrieve and load audio data,
@@ -255,14 +255,16 @@ class Separator(object):
 
         """
 
-
+        foldername = basename(dirname(audio_descriptor))
         filename = splitext(basename(audio_descriptor))[0]
         generated = []
         for instrument, data in sources.items():
             path = join(destination, filename_format.format(
                 filename=filename,
                 instrument=instrument,
-                codec=codec))
+                foldername=foldername,
+                codec=codec,
+                ))
             directory = os.path.dirname(path)
             if not os.path.exists(directory):
                 os.makedirs(directory)


### PR DESCRIPTION
# [Spleeter] - fix eval

## Description

The evaluate command was broken because of a bad naming format for outputs.
This fiw the evaluate command and makes it work again.