### PR TITLE
[DOC] fix for missing command

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -14,7 +14,7 @@ Those are the main contributing guidelines for contributing to this project:
 In order to contribute, the safest is to create your [own fork of spleeter](https://help.github.com/en/github/getting-started-with-github/fork-a-repo) first. The following set of commands will clone this new repository, create a virtual environment provisioned with the dependencies and run the tests (will take a few minutes):
 
 ```bash
-git clone https://github.com/<your_name>/spleeter
+git clone https://github.com/<your_name>/spleeter && cd spleeter
 python -m venv spleeterenv && source spleeterenv/bin/activate
 pip install -r requirements.txt && pip install pytest pytest-xdist
 make test

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ For a detailed documentation, please check the [repository wiki](https://github.
 The following set of commands will clone this repository, create a virtual environment provisioned with the dependencies and run the tests (will take a few minutes):
 
 ```bash
-git clone https://github.com/Deezer/spleeter
+git clone https://github.com/Deezer/spleeter && cd spleeter
 python -m venv spleeterenv && source spleeterenv/bin/activate
 pip install -r requirements.txt && pip install pytest pytest-xdist
 make test


### PR DESCRIPTION
# [Spleeter] - Fix Doc for missing command

## Description

There was a command missing for switching to the newly created directory in the quick setup commands.

## How this patch was tested

It is tested.

## Documentation link and external references

Please provide any info that may help us better understand your code.
