### PR TITLE
Allow negative durations to sample the end of a file

### DIFF
--- a/spleeter/audio/ffmpeg.py
+++ b/spleeter/audio/ffmpeg.py
@@ -97,7 +97,7 @@ class FFMPEGProcessAudioAdapter(AudioAdapter):
             sample_rate = metadata['sample_rate']
         output_kwargs = {'format': 'f32le', 'ar': sample_rate}
         if duration is not None:
-            output_kwargs['t' if duration > 0 else 'sseof'] = _to_ffmpeg_time(duration)
+            output_kwargs['t' if duration > 0 else 'sseof'] = str(duration)
         if offset is not None:
             output_kwargs['ss'] = _to_ffmpeg_time(offset)
         process = (

--- a/spleeter/audio/ffmpeg.py
+++ b/spleeter/audio/ffmpeg.py
@@ -97,7 +97,7 @@ class FFMPEGProcessAudioAdapter(AudioAdapter):
             sample_rate = metadata['sample_rate']
         output_kwargs = {'format': 'f32le', 'ar': sample_rate}
         if duration is not None:
-            output_kwargs['t'] = _to_ffmpeg_time(duration)
+            output_kwargs['t' if duration > 0 else 'sseof'] = _to_ffmpeg_time(duration)
         if offset is not None:
             output_kwargs['ss'] = _to_ffmpeg_time(offset)
         process = (


### PR DESCRIPTION
## Description

FFMpeg can sample from the end of an audio file using `sseof`. This is useful for when you don't know the duration of a file in advance (so cannot `length-duration=offset`). In addition, both `-t` and `-sseof` can accept string-formatted integers, wheras `sseof` cannot use hh:mm:ss format.

## How this patch was tested

I use this method in a different script. I know that the logic works.
