### PR TITLE
Allow negative durations to sample the end of a file

### DIFF
--- a/spleeter/audio/ffmpeg.py
+++ b/spleeter/audio/ffmpeg.py
@@ -115,7 +115,7 @@ class FFMPEGProcessAudioAdapter(AudioAdapter):
             sample_rate = metadata["sample_rate"]
         output_kwargs = {"format": "f32le", "ar": sample_rate}
         if duration is not None:
-            output_kwargs["t"] = str(dt.timedelta(seconds=duration))
+            output_kwargs["t" if duration > 0 else "sseof"] = str(duration)
         if offset is not None:
             output_kwargs["ss"] = str(dt.timedelta(seconds=offset))
         process = (


### PR DESCRIPTION
Replaces PR #484 

Both `t` and `sseof` accept a duration in seconds, so there is no need to convert to `hh:mm:ss` format.
`sseof` treats the end of the file as 0, so a negative value is relative to the end.

I use this process in ffmpeg directly right now, before handing it to Spleeter, but it would be neat if I could just hand spleeter a negative duration and get a sample relative to the end of the file.