### PR TITLE
Add options for getting spleeter version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "spleeter"
-version = "2.1.2"
+version = "2.2.0"
 description = "The Deezer source separation library with pretrained models based on tensorflow."
 authors = ["Deezer Research <spleeter@deezer.com>"]
 license = "MIT License"

--- a/spleeter/__main__.py
+++ b/spleeter/__main__.py
@@ -36,8 +36,9 @@ spleeter: Typer = Typer(add_completion=False)
 @spleeter.callback()
 def default(
     version: bool = VersionOption,
-) ->  None:
+) -> None:
     pass
+
 
 @spleeter.command()
 def train(

--- a/spleeter/__main__.py
+++ b/spleeter/__main__.py
@@ -11,7 +11,6 @@
         command function scope to avoid heavy import on CLI evaluation,
         leading to large bootstraping time.
 """
-
 import json
 from functools import partial
 from glob import glob
@@ -33,6 +32,12 @@ from .utils.logging import configure_logger, logger
 spleeter: Typer = Typer(add_completion=False)
 """ CLI application. """
 
+
+@spleeter.callback()
+def default(
+    version: bool = VersionOption,
+) ->  None:
+    pass
 
 @spleeter.command()
 def train(

--- a/spleeter/options.py
+++ b/spleeter/options.py
@@ -6,7 +6,7 @@
 from os.path import join
 from tempfile import gettempdir
 
-from typer import Argument, Option, echo, Exit
+from typer import Argument, Exit, Option, echo
 from typer.models import ArgumentInfo, OptionInfo
 
 from .audio import Codec, STFTBackend

--- a/spleeter/options.py
+++ b/spleeter/options.py
@@ -6,7 +6,7 @@
 from os.path import join
 from tempfile import gettempdir
 
-from typer import Argument, Option
+from typer import Argument, Option, echo, Exit
 from typer.models import ArgumentInfo, OptionInfo
 
 from .audio import Codec, STFTBackend
@@ -126,3 +126,12 @@ TrainingDataDirectoryOption: OptionInfo = Option(
 )
 
 VerboseOption: OptionInfo = Option(False, "--verbose", help="Enable verbose logs")
+
+
+def version_callback(value: bool):
+    if value:
+        from importlib.metadata import version
+        echo(f"Spleeter Version: {version('spleeter')}")
+        raise Exit()
+
+VersionOption: OptionInfo = Option(None, "--version", callback=version_callback, is_eager=True, help="Return Spleeter version")

--- a/spleeter/options.py
+++ b/spleeter/options.py
@@ -131,7 +131,15 @@ VerboseOption: OptionInfo = Option(False, "--verbose", help="Enable verbose logs
 def version_callback(value: bool):
     if value:
         from importlib.metadata import version
+
         echo(f"Spleeter Version: {version('spleeter')}")
         raise Exit()
 
-VersionOption: OptionInfo = Option(None, "--version", callback=version_callback, is_eager=True, help="Return Spleeter version")
+
+VersionOption: OptionInfo = Option(
+    None,
+    "--version",
+    callback=version_callback,
+    is_eager=True,
+    help="Return Spleeter version",
+)


### PR DESCRIPTION
# Add option for getting Spleeter version in command line

## Description

A new `--version` option was added to the CLI tool to display spleeter version.
