### PR TITLE
separator method's audio_descriptor param broken

### DIFF
--- a/spleeter/separator.py
+++ b/spleeter/separator.py
@@ -307,7 +307,7 @@ class Separator(object):
         return prediction
 
     def separate(
-        self, waveform: np.ndarray, audio_descriptor: Optional[str] = None
+        self, waveform: np.ndarray, audio_descriptor: Optional[str] = ""
     ) -> None:
         """
         Performs separation on a waveform.
@@ -318,6 +318,7 @@ class Separator(object):
             audio_descriptor (str):
                 (Optional) string describing the waveform (e.g. filename).
         """
+        
         backend: str = self._params["stft_backend"]
         if backend == STFTBackend.TENSORFLOW:
             return self._separate_tensorflow(waveform, audio_descriptor)


### PR DESCRIPTION
The default value of None breaks both `self._separate_tensorflow(waveform, audio_descriptor)` and `self._separate_librosa(waveform, audio_descriptor)`. An empty string works and seems to be what was intended?

# Pull request title

- [x] I read [contributing guideline](.github/CONTRIBUTING.md)

## Description

Trivial fix but pre-fix `separate` was breaking. The default value of audio_descriptor should be an empty `str`, not `None`. 

## How this patch was tested

You tested it, right?

- [x] I implemented unit test whicn ran successfully using `poetry run pytest tests/`
- [x] Code has been formatted using `poetry run black spleeter`
- [x] Imports has been formatted using `poetry run isort spleeter``

## Documentation link and external references

Please provide any info that may help us better understand your code.