### PR TITLE
Fixed broken Optional param in separate method

### DIFF
--- a/spleeter/separator.py
+++ b/spleeter/separator.py
@@ -318,6 +318,8 @@ class Separator(object):
             audio_descriptor (str):
                 (Optional) string describing the waveform (e.g. filename).
         """
+        if audio_descriptor is None:
+            audio_descriptor = ""
         backend: str = self._params["stft_backend"]
         if backend == STFTBackend.TENSORFLOW:
             return self._separate_tensorflow(waveform, audio_descriptor)


### PR DESCRIPTION
The `audio_descriptor` default value seems broken in the `separate` method of `Separator`. This is a fix.

# Pull request title

- [x] I read [contributing guideline](.github/CONTRIBUTING.md)

## Description

The default value for the `audio_descriptor` is `Optional[str]`, which is `None`, but this breaks the downstream methods in Tensorflow. The default value, if one is not specified, should be an empty string. This works.

## How this patch was tested

You tested it, right?

- [x] I implemented unit test whicn ran successfully using `poetry run pytest tests/`
- [x] Code has been formatted using `poetry run black spleeter`
- [x] Imports has been formatted using `poetry run isort spleeter``

## Documentation link and external references

Please provide any info that may help us better understand your code.