### PR TITLE
Hotfix for separate method to work back

### DIFF
--- a/spleeter/separator.py
+++ b/spleeter/separator.py
@@ -307,7 +307,7 @@ class Separator(object):
         return prediction
 
     def separate(
-        self, waveform: np.ndarray, audio_descriptor: Optional[str] = None
+        self, waveform: np.ndarray, audio_descriptor: Optional[str] = ""
     ) -> None:
         """
         Performs separation on a waveform.


### PR DESCRIPTION
Separate method no longer works because it passes `None` as default value for audio_descriptor parameter while the model does not support it.
The fix just replace `None` by `""`.