### PR TITLE
Fixed version command

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "spleeter"
-version = "2.2.0"
+version = "2.2.1"
 description = "The Deezer source separation library with pretrained models based on tensorflow."
 authors = ["Deezer Research <spleeter@deezer.com>"]
 license = "MIT License"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ tensorflow = "2.3.0"
 pandas = "1.1.2"
 numpy = "<1.19.0,>=1.16.0"
 importlib-resources = {version = "^4.1.1", python = "<3.7"}
+importlib-metadata = {version = "^3.0.0", python = "<3.8"}
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.2.1"

--- a/spleeter/options.py
+++ b/spleeter/options.py
@@ -130,7 +130,10 @@ VerboseOption: OptionInfo = Option(False, "--verbose", help="Enable verbose logs
 
 def version_callback(value: bool):
     if value:
-        from importlib.metadata import version
+        try:
+            from importlib.metadata import version
+        except ImportError:
+            from importlib_metadata import version
 
         echo(f"Spleeter Version: {version('spleeter')}")
         raise Exit()

--- a/tests/test_command.py
+++ b/tests/test_command.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python
+# coding: utf8
+
+""" Unit testing for Separator class. """
+
+__email__ = 'research@deezer.com'
+__author__ = 'Deezer Research'
+__license__ = 'MIT License'
+
+from spleeter.__main__ import spleeter
+from typer.testing import CliRunner
+
+
+def test_version():
+
+    runner = CliRunner()
+
+    # execute spleeter version command
+    result = runner.invoke(spleeter, [
+        '--version',
+    ])


### PR DESCRIPTION
The `--command` version was throwing an import error when run on python <3.8.
This PR fix the import of importlib.metadata (with backport import for python<3.8)