### PR TITLE
PR template: Fix broken link to contributing.md

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 # Pull request title
 
-- [ ] I read [contributing guideline](.github/CONTRIBUTING.md)
+- [ ] I read [contributing guideline](https://github.com/deezer/spleeter/blob/master/.github/CONTRIBUTING.md)
 - [ ] I didn't find a similar pull request already open.
 - [ ] My PR is related to Spleeter only, not a derivative product (such as Webapplication, or GUI provided by others)
 


### PR DESCRIPTION
The link is broken on actual PR pages.
Not using relative link, as it would be github-specific anyway, and the relative link would be broken on some other pages.

# Pull request title

- [ ] I read [contributing guideline](.github/CONTRIBUTING.md)
- [x] I didn't find a similar pull request already open.
- [x] My PR is related to Spleeter only, not a derivative product (such as Webapplication, or GUI provided by others)

## Description

I didn't read the contribution guidelines.

## How this patch was tested

You tested it, right?

I clicked some links.