### PR TITLE
M1 native install dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ You need first to install `ffmpeg` and `libsndfile`. It can be done on most plat
 ```bash
 # install dependencies using conda
 conda install -c conda-forge ffmpeg libsndfile
+# some extra deps for mac users
+# conda install -c apple tensorflow-deps==2.5.0 llvmlite==0.36.0 numba pandas==1.3.3
 # install spleeter with pip
 pip install spleeter
 # download an example audio file (if you don't have wget, use another tool for downloading)

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ You need first to install `ffmpeg` and `libsndfile`. It can be done on most plat
 ```bash
 # install dependencies using conda
 conda install -c conda-forge ffmpeg libsndfile
-# some extra deps for mac users
+# for mac users, install these additional dependencies for TensorFlow compatibility
 # conda install -c apple tensorflow-deps==2.5.0 llvmlite==0.36.0 numba pandas==1.3.3
 # install spleeter with pip
 pip install spleeter
@@ -59,8 +59,6 @@ spleeter separate -p spleeter:2stems -o output audio_example.mp3
 ```
 
 > :warning: Note that we no longer recommend using `conda` for installing spleeter.
-
-> ⚠️ There are known issues with Apple M1 chips, mostly due to TensorFlow compatibility. Until these are fixed, you can use [this workaround](https://github.com/deezer/spleeter/issues/607#issuecomment-1021669444).
 
 You should get two separated audio files (`vocals.wav` and `accompaniment.wav`) in the `output/audio_example` folder.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,9 @@ typer = "^0.3.2"
 librosa = "0.8.0"
 musdb = {version = "0.3.1", optional = true}
 museval = {version = "0.3.0", optional = true}
-tensorflow = "2.5.0"
+tensorflow = {version = "2.5.0", markers = "sys_platform != 'darwin'"}
+tensorflow-macos = {version = "2.5.0", markers = "sys_platform == 'darwin'"}
+tensorflow-metal = {version = "0.4.0", markers = "sys_platform == 'darwin'"}
 pandas = "^1.1.2"
 numpy = "<1.20.0,>=1.16.0"
 importlib-resources = {version = "^4.1.1", python = "<3.7"}


### PR DESCRIPTION
# M1 native install dependencies

- [X] I read [contributing guideline](https://github.com/deezer/spleeter/blob/master/.github/CONTRIBUTING.md)
- [X] I didn't find a similar pull request already open.
- [X] My PR is related to Spleeter only, not a derivative product (such as Webapplication, or GUI provided by others)

## Description

Updates instructions for M1, and adds Darwin dependencies to pyproject.toml. The platform marker lets us pin a tf version specific for Darwin platforms to maintain compatibility.

## How this patch was tested

I've tested these instructions on my M1, but could use testing on other machines (Darwin and otherwise) just to make sure everything's 100p.

## Documentation link and external references

Mostly just put this together from other comments floating around on the repo.
