### PR TITLE
Disambiguate env vars for model download from Github-reserved values

### DIFF
--- a/spleeter/model/provider/github.py
+++ b/spleeter/model/provider/github.py
@@ -85,9 +85,9 @@ class GithubModelProvider(ModelProvider):
                 Created instance.
         """
         return cls(
-            environ.get("GITHUB_HOST", cls.DEFAULT_HOST),
-            environ.get("GITHUB_REPOSITORY", cls.DEFAULT_REPOSITORY),
-            environ.get("GITHUB_RELEASE", cls.LATEST_RELEASE),
+            environ.get("GITHUB_MODEL_HOST", cls.DEFAULT_HOST),
+            environ.get("GITHUB_MODEL_REPOSITORY", cls.DEFAULT_REPOSITORY),
+            environ.get("GITHUB_MODEL_RELEASE", cls.LATEST_RELEASE),
         )
 
     def checksum(self, name: str) -> str:


### PR DESCRIPTION
# Disambiguate env vars for model download from Github-reserved values

- [x] I read [contributing guideline](https://github.com/deezer/spleeter/blob/master/.github/CONTRIBUTING.md)
- [x] I didn't find a similar pull request already open.
- [x] My PR is related to Spleeter only, not a derivative product (such as Webapplication, or GUI provided by others)

## Description

When running in a Github Action runner, `GITHUB_REPOSITORY` is a reserved environment variable that ideally should not be overridden for fear of erratic/unexpected side-effects.

This commit renames the environment variables to be a bit more distinct and related to their purpose within spleeter i.e. for building a model download destination.

Fixes https://github.com/deezer/spleeter/issues/781

## How this patch was tested

Ran spleeter in a Github Action job, without having to override the new `GITHUB_MODEL_REPOSITORY` variable, and it automatically defaulted to `deezer/spleeter` as expected, rather than attempting to hit a URL at `my-org/my-repo`.

Unit test was NOT added, because the existing test suite runs an `httpx` `GET` request, which already fails to being with 
 (attempting to access a public URL from a command line test suite run). Adequate tests for this functionality already do not exist, and would ideally require adding HTTP request/response stubs (perhaps via (pytest-httpx)[https://pypi.org/project/pytest-httpx/]). For the simple nature of this solution, I preferred to not introduce a whole new dependency to the call stack... but happy to do so if deemed necessary for the acceptance of this PR.

- [ ] I implemented unit test which ran successfully using `poetry run pytest tests/`
- [x] Code has been formatted using `poetry run black spleeter`
- [x] Imports has been formatted using `poetry run isort spleeter``
