### PR TITLE
spleeter -h is no longer supported; changing to spleeter --help

### DIFF
--- a/spleeter.ipynb
+++ b/spleeter.ipynb
@@ -115,7 +115,7 @@
    },
    "outputs": [],
    "source": [
-    "!spleeter separate -h"
+    "!spleeter separate --help"
    ]
   },
   {


### PR DESCRIPTION
# Pull request title

- [x] I read [contributing guideline](https://github.com/deezer/spleeter/blob/master/.github/CONTRIBUTING.md)
- [x] I didn't find a similar pull request already open.
- [x] My PR is related to Spleeter only, not a derivative product (such as Webapplication, or GUI provided by others)

## Description

A few sentences describing the overall goals of the pull request's commits.
<s>
## How this patch was tested

You tested it, right?

- [ ] I implemented unit test whicn ran successfully using `poetry run pytest tests/`
- [ ] Code has been formatted using `poetry run black spleeter`
- [ ] Imports has been formatted using `poetry run isort spleeter``</s>

## Documentation link and external references

Please provide any info that may help us better understand your code.

`spleeter -h` is no longer a valid option, but you can still use `spleeter --help`. 