### PR TITLE
Fix outdated command-line argument in Python notebook

### DIFF
--- a/spleeter.ipynb
+++ b/spleeter.ipynb
@@ -115,7 +115,7 @@
    },
    "outputs": [],
    "source": [
-    "!spleeter separate -h"
+    "!spleeter separate --help"
    ]
   },
   {


### PR DESCRIPTION
Changed `spleeter seperate -h` to `spleeter seperate --help`

# Pull request title

- [ ] I read [contributing guideline](https://github.com/deezer/spleeter/blob/master/.github/CONTRIBUTING.md)
- [ ] I didn't find a similar pull request already open.
- [ ] My PR is related to Spleeter only, not a derivative product (such as Webapplication, or GUI provided by others)

## Description

A few sentences describing the overall goals of the pull request's commits.

## How this patch was tested

You tested it, right?

- [ ] I implemented unit test whicn ran successfully using `poetry run pytest tests/`
- [ ] Code has been formatted using `poetry run black spleeter`
- [ ] Imports has been formatted using `poetry run isort spleeter``

## Documentation link and external references

Please provide any info that may help us better understand your code.
