### PR TITLE
Update spleeter.ipynb

### DIFF
--- a/spleeter.ipynb
+++ b/spleeter.ipynb
@@ -115,7 +115,7 @@
    },
    "outputs": [],
    "source": [
-    "!spleeter separate -h"
+    "!spleeter separate"
    ]
   },
   {


### PR DESCRIPTION
Separate does not have a "-h" anymore it seems.

# Pull request title

- [x] I read [contributing guideline](https://github.com/deezer/spleeter/blob/master/.github/CONTRIBUTING.md)
- [x] I didn't find a similar pull request already open.
- [x] My PR is related to Spleeter only, not a derivative product (such as Webapplication, or GUI provided by others)

## Description

On the collab, "-h" causes an error when running the CLI. This removes the -h and the command prints out the help information without it.

## How this patch was tested

You tested it, right?

- [x] I implemented unit test whicn ran successfully using `poetry run pytest tests/`
- [x] Code has been formatted using `poetry run black spleeter`
- [x] Imports has been formatted using `poetry run isort spleeter``

## Documentation link and external references
lmk if you need this